### PR TITLE
Update to qt-4.8.6

### DIFF
--- a/files/brews/qt.rb
+++ b/files/brews/qt.rb
@@ -2,19 +2,16 @@ require 'formula'
 
 class Qt < Formula
   homepage 'http://qt-project.org/'
-  if MacOS.version < :mavericks
-    url 'http://download.qt-project.org/official_releases/qt/4.8/4.8.5/qt-everywhere-opensource-src-4.8.5.tar.gz'
-    sha1 '745f9ebf091696c0d5403ce691dc28c039d77b9e'
-  else
-    # This is a snapshot of the current qt-4.8 branch. It's been used by a
-    # bunch of people to get Qt working on Mavericks and 4.8.5 needs too many
-    # patches to compile any time soon (January-ish):
-    # http://permalink.gmane.org/gmane.comp.lib.qt.devel/13812
-    url 'https://github.com/qtproject/qt/archive/f44310c25b372f494586dbb5b305f7e81ca63000.tar.gz'
-    sha1 '51548326463068912fb4d9de04b0f6b2e267d064'
-  end
+  url "http://download.qt-project.org/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz"
+  sha1 "ddf9c20ca8309a116e0466c42984238009525da6"
 
-  version "4.8.5-boxen2"
+  version "4.8.6-boxen1"
+
+  bottle do
+    sha1 "114242a849d7ade7d55d46097b1f7790b871df8f" => :mavericks
+    sha1 "5e022a402437b0a1bf5bf2d2d67491280f73a7a8" => :mountain_lion
+    sha1 "212fce47b1f2f2d3bf4397db7d5967fb59223cec" => :lion
+  end
 
   option :universal
   option 'with-qt3support', 'Build with deprecated Qt3Support module support'
@@ -23,24 +20,24 @@ class Qt < Formula
 
   depends_on "d-bus" => :optional
   depends_on "mysql" => :optional
-  depends_on "libpng"
 
-  odie 'qt: --with-qtdbus has been renamed to --with-d-bus' if build.include? 'with-qtdbus'
-  odie 'qt: --with-demos-examples is no longer supported' if build.include? 'with-demos-examples'
-  odie 'qt: --with-debug-and-release is no longer supported' if build.include? 'with-debug-and-release'
+  odie 'qt: --with-qtdbus has been renamed to --with-d-bus' if build.with? "qtdbus"
+  odie 'qt: --with-demos-examples is no longer supported' if build.with? "demos-examples"
+  odie 'qt: --with-debug-and-release is no longer supported' if build.with? "debug-and-release"
 
   def install
     ENV.universal_binary if build.universal?
 
     args = ["-prefix", prefix,
             "-system-zlib",
+            "-qt-libtiff", "-qt-libpng", "-qt-libjpeg",
             "-confirm-license", "-opensource",
             "-nomake", "demos", "-nomake", "examples",
             "-cocoa", "-fast", "-release"]
 
     # we have to disable these to avoid triggering optimization code
     # that will fail in superenv (in --env=std, Qt seems aware of this)
-    args << '-no-3dnow' << '-no-ssse3' if superenv?
+    args << "-no-3dnow" << "-no-ssse3" if superenv?
 
     args << "-L#{MacOS::X11.lib}" << "-I#{MacOS::X11.include}" if MacOS::X11.installed?
 
@@ -57,11 +54,12 @@ class Qt < Formula
     args << "-plugin-sql-mysql" if build.with? 'mysql'
 
     if build.with? 'd-bus'
-      dbus_opt = Formula.factory('d-bus').opt_prefix
+      dbus_opt = Formula["d-bus"].opt_prefix
       args << "-I#{dbus_opt}/lib/dbus-1.0/include"
       args << "-I#{dbus_opt}/include/dbus-1.0"
       args << "-L#{dbus_opt}/lib"
       args << "-ldbus-1"
+      args << "-dbus-linked"
     end
 
     if build.with? 'qt3support'
@@ -70,9 +68,7 @@ class Qt < Formula
       args << "-no-qt3support"
     end
 
-    unless build.with? 'docs'
-      args << "-nomake" << "docs"
-    end
+    args << "-nomake" << "docs" if build.without? 'docs'
 
     if MacOS.prefer_64_bit? or build.universal?
       args << '-arch' << 'x86_64'
@@ -96,20 +92,16 @@ class Qt < Formula
     (prefix+'q3porting.xml').unlink if build.without? 'qt3support'
 
     # Some config scripts will only find Qt in a "Frameworks" folder
-    frameworks.mkpath
-    ln_s Dir["#{lib}/*.framework"], frameworks
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
 
     # The pkg-config files installed suggest that headers can be found in the
     # `include` directory. Make this so by creating symlinks from `include` to
     # the Frameworks' Headers folders.
-    Pathname.glob(lib + '*.framework/Headers').each do |path|
-      framework_name = File.basename(File.dirname(path), '.framework')
-      ln_s path.realpath, include+framework_name
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
     end
 
-    Pathname.glob(bin + '*.app').each do |path|
-      mv path, prefix
-    end
+    Pathname.glob("#{bin}/*.app") { |app| mv app, prefix }
   end
 
   test do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class qt {
   }
 
   package { 'boxen/brews/qt':
-    ensure  => '4.8.5-boxen2',
+    ensure  => '4.8.6-boxen1',
     require => Class['xquartz'],
   }
 }

--- a/spec/classes/qt_spec.rb
+++ b/spec/classes/qt_spec.rb
@@ -15,6 +15,6 @@ describe 'qt' do
     should include_class('xquartz')
 
     should contain_homebrew__formula('qt')
-    should contain_package('boxen/brews/qt').with_ensure('4.8.5-boxen2')
+    should contain_package('boxen/brews/qt').with_ensure('4.8.6-boxen1')
   end
 end


### PR DESCRIPTION
The upstream homebrew formula has fixed some annoying libpng linking issues, and now uses an official point release rather than an arbitrary revision of qt that compiles and runs on Mavericks.
